### PR TITLE
Add/engine base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ name = "last_stand"
 version = "0.1.0"
 dependencies = [
  "macroquad",
+ "nonmax",
 ]
 
 [[package]]
@@ -199,6 +200,12 @@ name = "ndk-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 macroquad = "0.4.14"
+nonmax = "0.5.5"

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,0 +1,190 @@
+use std::{collections::VecDeque, ops::Range};
+
+use macroquad::math::{Circle, Rect, Vec2};
+use nonmax::NonMaxU16;
+
+use crate::ecs::{
+    component::{Component, ComponetPool},
+    entity::Entity,
+};
+
+/// A mask determining the layer within collision system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct CollisionMask(pub u8);
+
+impl CollisionMask {
+    /// Returns `true` if the two collision masks have
+    /// overlapping layers.
+    pub fn overlaps(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+/// A collider component.
+#[derive(Debug, Clone, Copy)]
+pub struct Collider {
+    /// Shape and position of the collider.
+    pub shape: Circle,
+    /// The layers inside of which this collider can be detected.
+    pub monitorable: CollisionMask,
+    /// The layers that the collider will scan to detect collisions.
+    pub monitoring: CollisionMask,
+}
+
+impl Component for Collider {}
+
+/// Determines the shape and precision of the [`CollisionGrid`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CollisionGridParams {
+    pub bounding_rect: Rect,
+    pub resolution: (usize, usize),
+}
+
+/// Data structure that allows to efficiently detect collisions
+/// for the [`Collider`] components.
+#[derive(Debug, Clone, Default)]
+pub struct CollisionGrid {
+    params: CollisionGridParams,
+    entities: Vec<Entity>,
+    cell_ranges: Vec<Range<u16>>,
+}
+
+impl CollisionGrid {
+    /// Constructs and empty collision grid.
+    pub fn new() -> Self {
+        Default::default()
+    }
+    /// Returns the params from the last time the grid was updated.
+    pub fn params(&self) -> &CollisionGridParams {
+        &self.params
+    }
+    /// Returns the entities that might have collisions in the cell \[`x`, `y`\].
+    ///
+    /// # Panics
+    /// Panics if the `x` or `y` exceeds the current resolution.
+    pub fn cell(&self, x: usize, y: usize) -> &[Entity] {
+        let range = self.cell_ranges[self.cell_index(x, y)].clone();
+        let range = Range {
+            start: range.start as usize,
+            end: range.end as usize,
+        };
+        &self.entities[range]
+    }
+    /// Rebuilds the collision grid with the new parameters.
+    pub fn update(&mut self, colliders: &ComponetPool<Collider>, params: CollisionGridParams) {
+        self.params = params;
+        let cell_count = params.resolution.0.strict_mul(params.resolution.1);
+
+        // Pass 1: count cells.
+        self.cell_ranges.clear();
+        self.cell_ranges.resize(cell_count, Range::default());
+        for (entity, &collider) in colliders.iter() {
+            for (x, y) in self.overlapping_cells(collider) {
+                let index = self.cell_index(x, y);
+                self.cell_ranges[index].end += 1;
+            }
+        }
+        // `self.cell_ranges[i]` is `0..count`, where `count` is number of entities in the cell
+
+        // Pass 2: build ranges.
+        let mut total = 0;
+        for y in 0..params.resolution.0 {
+            for x in 0..params.resolution.1 {
+                let index = self.cell_index(x, y);
+                let range = &mut self.cell_ranges[index];
+                let count = range.end as usize;
+                range.start = total as u16;
+                range.end = total as u16;
+                total += count;
+            }
+        }
+        // `self.cell_ranges[i]` is `index..index` where `index` is the future begining of the range.
+        // `total` is the total number of entities.
+
+        // Pass 3: fill entities.
+        self.entities.clear();
+        self.entities.reserve(total);
+        for (entity, &collider) in colliders.iter() {
+            for (x, y) in self.overlapping_cells(collider) {
+                let index = self.cell_index(x, y);
+                let range = &mut self.cell_ranges[index];
+                self.entities.spare_capacity_mut()[range.end as usize].write(entity);
+                range.end += 1;
+            }
+        }
+        // `self.cell_ranges[i]` is `start..end` where `start` and `end` indicate the positions
+        // of the corresponding entities within the spare capacity of `self.entities`.
+
+        // SAFETY: This is safe since `total` is the total number of entities
+        // and we filled in the entities into the spare capacity in "pass 3".
+        unsafe {
+            self.entities.set_len(total);
+        }
+    }
+    /// Returns the other entity from the first collision pair with the supplied entity.
+    ///
+    /// # Panics
+    /// Panics if the supplied entity does not have a [`Collider`] component.
+    pub fn any_collision(
+        &self,
+        colliders: &ComponetPool<Collider>,
+        entity: Entity,
+    ) -> Option<Entity> {
+        let collider = colliders
+            .get(entity)
+            .copied()
+            .expect("Entity does not have a collider!");
+        for (x, y) in self.overlapping_cells(collider) {
+            for &entity in self.cell(x, y) {
+                let other = colliders.get(entity).unwrap();
+                if !collider.monitoring.overlaps(other.monitorable) {
+                    continue;
+                }
+                if !collider.shape.overlaps(&other.shape) {
+                    continue;
+                }
+                return Some(entity);
+            }
+        }
+        None
+    }
+    /// Returns the index in the cell array for the specified point.
+    ///
+    /// # Panics
+    /// Panics if the point is out of bounds.
+    fn cell_index(&self, x: usize, y: usize) -> usize {
+        let res = self.params.resolution;
+        assert!(x < res.0 && y < res.1, "The cell index is out of bounds!");
+        y * res.0 + x
+    }
+    /// Returns an iterator of all cell indices that overlap with the provided collider.
+    fn overlapping_cells(
+        &self,
+        collider: Collider,
+    ) -> impl Iterator<Item = (usize, usize)> + 'static {
+        let min = Vec2::new(
+            collider.shape.x - collider.shape.r,
+            collider.shape.y - collider.shape.r,
+        );
+        let max = Vec2::new(
+            collider.shape.x + collider.shape.r,
+            collider.shape.y + collider.shape.r,
+        );
+        let res = Vec2::new(
+            self.params.resolution.0 as f32,
+            self.params.resolution.1 as f32,
+        );
+        let origin = self.params.bounding_rect.point();
+        let local_min = ((min - origin) / res).max(Vec2::ZERO).floor();
+        let local_max = ((max - origin) / res).min(res).ceil();
+        let range_x = Range {
+            start: local_min.x as usize,
+            end: local_max.x as usize,
+        };
+        let range_y = Range {
+            start: local_min.y as usize,
+            end: local_max.y as usize,
+        };
+        range_y.flat_map(move |y| range_x.clone().map(move |x| (x, y)))
+    }
+}

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -1,0 +1,2 @@
+pub mod component;
+pub mod entity;

--- a/src/ecs/component.rs
+++ b/src/ecs/component.rs
@@ -1,0 +1,158 @@
+use std::any::Any;
+
+use nonmax::NonMaxU16;
+
+use crate::ecs::{
+    component::iter::{Entities, Iter, IterMut, Values, ValuesMut},
+    entity::Entity,
+};
+
+/// Marker trait for components.
+pub trait Component: 'static {}
+
+mod iter;
+
+/// Stores the components of type `T` for each entity.
+#[derive(Debug, Clone)]
+pub struct ComponetPool<T> {
+    values: Vec<T>,
+    entities: Vec<Entity>,
+    index_lookup: Box<[Option<NonMaxU16>]>,
+}
+
+impl<T> ComponetPool<T> {
+    /// Constructs a new component pool.
+    pub fn new() -> Self {
+        let values = Vec::new();
+        let entities = Vec::new();
+        let index_lookup = vec![None; Entity::INDEX_MAX].into_boxed_slice();
+        Self {
+            values,
+            entities,
+            index_lookup,
+        }
+    }
+    /// Adds the component to the entity.
+    ///
+    /// # Panics
+    /// Panics if the entity already has the component.
+    pub fn insert(&mut self, entity: Entity, value: T) {
+        assert!(!self.contains_entity(entity), "Component already exists!");
+        let index = self.values.len() as u16;
+        self.index_lookup[entity.index().get() as usize] = Some(NonMaxU16::new(index).unwrap());
+        self.entities.push(entity);
+        self.values.push(value);
+    }
+    /// Removes the component from the entity.
+    ///
+    /// # Panics
+    /// Panics if the entity does not have the component.
+    pub fn remove(&mut self, entity: Entity) {
+        assert!(self.try_remove(entity), "Component does not exist!");
+    }
+    /// Tries to remove the component from the entity and
+    /// returns `true` if the component used to exist.
+    pub fn try_remove(&mut self, entity: Entity) -> bool {
+        let Some(index) = self.index(entity) else {
+            return false;
+        };
+        self.index_lookup[entity.index().get() as usize] = None;
+        self.values.swap_remove(index);
+        self.entities.swap_remove(index);
+        true
+    }
+    /// Returns `true` if the supplied entity has the component `T` in this pool.
+    pub fn contains_entity(&self, entity: Entity) -> bool {
+        self.index(entity).is_some()
+    }
+    /// Returns the reference to the component for the supplied entity.
+    pub fn get(&self, entity: Entity) -> Option<&T> {
+        self.index(entity).map(|index| &self.values[index])
+    }
+    /// Returns the mutable reference to the component for the supplied entity.
+    pub fn get_mut(&mut self, entity: Entity) -> Option<&mut T> {
+        self.index(entity).map(|index| &mut self.values[index])
+    }
+    /// Returns an iterator over the entities with the component.
+    pub fn entities(&self) -> Entities<'_> {
+        Entities(self.entities.iter())
+    }
+    /// Returns an iterator over the values of the components.
+    pub fn values(&self) -> Values<'_, T> {
+        Values(self.values.iter())
+    }
+    /// Returns a mutable iterator over the values of the components.
+    pub fn values_mut(&mut self) -> ValuesMut<'_, T> {
+        ValuesMut(self.values.iter_mut())
+    }
+    /// Returns an iterator over the entities their corresponding components.
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            entity_iter: Entities(self.entities.iter()),
+            value_iter: Values(self.values.iter()),
+        }
+    }
+    /// Returns a mutable iterator over the entities their corresponding components.
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        IterMut {
+            entity_iter: Entities(self.entities.iter()),
+            value_iter: ValuesMut(self.values.iter_mut()),
+        }
+    }
+    /// Reserve capacity for at least `additional` more components.
+    pub fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional);
+        self.entities.reserve(additional);
+    }
+    /// Shrinks the capacity of the component pool with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the supplied value.
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.values.shrink_to(min_capacity);
+        self.entities.shrink_to(min_capacity);
+    }
+    /// Shrinks the capacity of the component pool as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+        self.entities.shrink_to_fit();
+    }
+    /// Returns the index in the component array for the supplied enity.
+    fn index(&self, entity: Entity) -> Option<usize> {
+        self.index_lookup[entity.index().get() as usize].map(|index| index.get() as usize)
+    }
+}
+
+/// Trait that erases the `T` from the component pool.
+pub trait UntypedComponentPool: Any {
+    fn remove(&mut self, entity: Entity);
+    fn try_remove(&mut self, entity: Entity) -> bool;
+    fn contains_entity(&self, entity: Entity) -> bool;
+    fn entities(&self) -> Entities<'_>;
+    fn reserve(&mut self, additional: usize);
+    fn shrink_to(&mut self, min_capacity: usize);
+    fn shrink_to_fit(&mut self);
+}
+
+impl<T: Component> UntypedComponentPool for ComponetPool<T> {
+    fn remove(&mut self, entity: Entity) {
+        ComponetPool::<T>::remove(self, entity)
+    }
+    fn try_remove(&mut self, entity: Entity) -> bool {
+        ComponetPool::<T>::try_remove(self, entity)
+    }
+    fn contains_entity(&self, entity: Entity) -> bool {
+        ComponetPool::<T>::contains_entity(self, entity)
+    }
+    fn entities(&self) -> Entities<'_> {
+        ComponetPool::<T>::entities(self)
+    }
+    fn reserve(&mut self, additional: usize) {
+        ComponetPool::<T>::reserve(self, additional)
+    }
+    fn shrink_to(&mut self, min_capacity: usize) {
+        ComponetPool::<T>::shrink_to(self, min_capacity)
+    }
+    fn shrink_to_fit(&mut self) {
+        ComponetPool::<T>::shrink_to_fit(self)
+    }
+}

--- a/src/ecs/component.rs
+++ b/src/ecs/component.rs
@@ -56,9 +56,12 @@ impl<T> ComponetPool<T> {
         let Some(index) = self.index(entity) else {
             return false;
         };
-        self.index_lookup[entity.index().get() as usize] = None;
+        let swapped = self.entities().last().unwrap();
         self.values.swap_remove(index);
         self.entities.swap_remove(index);
+        self.index_lookup[swapped.index().get() as usize] =
+            Some(NonMaxU16::new(index as u16).unwrap());
+        self.index_lookup[entity.index().get() as usize] = None;
         true
     }
     /// Returns `true` if the supplied entity has the component `T` in this pool.

--- a/src/ecs/component/iter.rs
+++ b/src/ecs/component/iter.rs
@@ -1,0 +1,92 @@
+use crate::ecs::component::Entity;
+
+#[derive(Debug, Clone)]
+pub struct Values<'a, T>(pub(super) std::slice::Iter<'a, T>);
+
+impl<'a, T> Iterator for Values<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+}
+
+#[derive(Debug)]
+pub struct ValuesMut<'a, T>(pub(super) std::slice::IterMut<'a, T>);
+
+impl<'a, T> Iterator for ValuesMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Entities<'a>(pub(super) std::slice::Iter<'a, Entity>);
+
+impl<'a> Iterator for Entities<'a> {
+    type Item = Entity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().copied()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n).copied()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Iter<'a, T> {
+    pub(super) entity_iter: Entities<'a>,
+    pub(super) value_iter: Values<'a, T>,
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = (Entity, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some((self.entity_iter.next()?, self.value_iter.next()?))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.entity_iter.size_hint()
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        Some((self.entity_iter.nth(n)?, self.value_iter.nth(n)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct IterMut<'a, T> {
+    pub(super) entity_iter: Entities<'a>,
+    pub(super) value_iter: ValuesMut<'a, T>,
+}
+
+impl<'a, T> Iterator for IterMut<'a, T> {
+    type Item = (Entity, &'a mut T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some((self.entity_iter.next()?, self.value_iter.next()?))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.entity_iter.size_hint()
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        Some((self.entity_iter.nth(n)?, self.value_iter.nth(n)?))
+    }
+}

--- a/src/ecs/entity.rs
+++ b/src/ecs/entity.rs
@@ -1,0 +1,114 @@
+use std::{
+    any::TypeId,
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap, VecDeque},
+};
+
+use nonmax::NonMaxU16;
+
+use crate::ecs::component::{Component, ComponetPool, UntypedComponentPool};
+
+/// ECS entity ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Entity {
+    index: NonMaxU16,
+    generation: NonMaxU16,
+}
+
+impl Entity {
+    /// Returns the maximal index of the entity.
+    pub(super) const INDEX_MAX: usize = NonMaxU16::MAX.get() as usize;
+
+    /// Returns the index of the entity.
+    pub(super) fn index(self) -> NonMaxU16 {
+        self.index
+    }
+    /// Returns the generation of the entity.
+    pub(super) fn generation(self) -> NonMaxU16 {
+        self.generation
+    }
+}
+
+/// A registry storing the state of entities and their components.
+pub struct World {
+    components: HashMap<TypeId, Box<RefCell<dyn UntypedComponentPool>>>,
+    record_lookup: Box<[EntityRecord]>,
+    free_indices: VecDeque<NonMaxU16>,
+}
+
+impl World {
+    /// Creates a new entity registry.
+    pub fn new() -> Self {
+        let components = HashMap::new();
+        let record_lookup = vec![EntityRecord::default(); Entity::INDEX_MAX].into_boxed_slice();
+        let free_indices = VecDeque::from_iter(
+            (0..=Entity::INDEX_MAX).map(|index| NonMaxU16::new(index as u16).unwrap()),
+        );
+        Self {
+            components,
+            record_lookup,
+            free_indices,
+        }
+    }
+    /// Registers the specified type as a component.
+    pub fn register_type<T: Component>(&mut self) {
+        let id = TypeId::of::<T>();
+        let Entry::Vacant(entry) = self.components.entry(id) else {
+            return;
+        };
+        entry.insert(Box::new(RefCell::new(ComponetPool::<T>::new())));
+    }
+    /// Returns the component pool for the specified type.
+    pub fn pool(&self, id: TypeId) -> Option<&RefCell<dyn UntypedComponentPool>> {
+        self.components.get(&id).map(|boxed| boxed.as_ref())
+    }
+    /// Constructs a new entity.
+    ///
+    /// # Panics
+    /// Panics if the entity limit ([`ENTITY_INDEX_MAX`]) is exceeded.
+    pub fn create_entity(&mut self) -> Entity {
+        assert!(!self.free_indices.is_empty(), "Entity limit exceeded!");
+        let index: NonMaxU16 = self.free_indices.pop_back().unwrap();
+        let record = &mut self.record_lookup[index.get() as usize];
+        debug_assert!(!record.is_alive);
+        record.is_alive = true;
+        let generation = record.generation;
+        Entity { index, generation }
+    }
+    /// Returns `true` if the specified entity is currently alive.
+    pub fn is_entity_alive(&self, entity: Entity) -> bool {
+        let record = self.record_lookup[entity.index.get() as usize];
+        record.is_alive && record.generation == entity.generation
+    }
+    /// Destroys the entity and all of its components.
+    ///
+    /// # Panics
+    /// - Panics if some of the supplied entities do not exist.
+    /// - Panics if some of the supplied eneities' component pools are already in use.
+    pub fn destroy_entities(&mut self, entities: &[Entity]) {
+        for &entity in entities {
+            assert!(self.is_entity_alive(entity), "Entity does not exist!");
+        }
+
+        for pool in self.components.values() {
+            let mut pool = pool.borrow_mut();
+            for &entity in entities {
+                pool.try_remove(entity);
+            }
+        }
+
+        for &entity in entities {
+            let record = &mut self.record_lookup[entity.index.get() as usize];
+            record.is_alive = false;
+            let generation = (record.generation.get() + 1).rem_euclid(NonMaxU16::MAX.get());
+            record.generation = NonMaxU16::new(generation).unwrap();
+        }
+    }
+}
+
+/// Record storing the current state of the entity with some index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+struct EntityRecord {
+    is_alive: bool,
+    generation: NonMaxU16,
+}

--- a/src/ecs/entity.rs
+++ b/src/ecs/entity.rs
@@ -1,7 +1,7 @@
 use std::{
     any::TypeId,
     cell::RefCell,
-    collections::{hash_map::Entry, HashMap, VecDeque},
+    collections::{HashMap, VecDeque, hash_map::Entry},
 };
 
 use nonmax::NonMaxU16;
@@ -102,6 +102,7 @@ impl World {
             record.is_alive = false;
             let generation = (record.generation.get() + 1).rem_euclid(NonMaxU16::MAX.get());
             record.generation = NonMaxU16::new(generation).unwrap();
+            self.free_indices.push_front(entity.index);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 #[allow(unused)]
+mod collision;
+#[allow(unused)]
 mod ecs;
 
 #[macroquad::main("Last Stand")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#[allow(unused)]
+mod ecs;
+
 #[macroquad::main("Last Stand")]
 async fn main() {
     todo!()


### PR DESCRIPTION
# Add engine basics
Added the ECS and the collision system.

# Details
- Added entities, components and an ECS `World` a.k.a. the entity registry.
- Added simple collision system. Update the `CollisionGrid` each physics frame and call `any_collision` on it to detect collisions.